### PR TITLE
Fix Astro package main entry

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -8,7 +8,7 @@
 		"type": "git",
 		"url": "https://github.com/michaelhthomas/critters-rs"
 	},
-	"main": "index.js",
+	"main": "dist/index.js",
 	"type": "module",
 	"keywords": [
 		"astro-integration",


### PR DESCRIPTION
## Summary
- Update `@critters-rs/astro`'s package `main` field from the missing root `index.js` to the built `dist/index.js` entry.
- Keep the `main` field aligned with the existing `exports["."].default` target.

## Why
The published `@critters-rs/astro@1.2.0` tarball declares `main: "index.js"`, but it does not include a root `index.js`. It does include `dist/index.js` and already exports that file through the package `exports` map. Tools or consumers that still inspect `main` can resolve a missing file today.

## Validation
- `git diff --check HEAD~1..HEAD`
- Packed and inspected `@critters-rs/astro@1.2.0`: published `main` is `index.js`, root `index.js` is absent, and `dist/index.js` is present.
- Confirmed the patched manifest points `main` to `dist/index.js`.

Note: a full `corepack pnpm@9.12.0 install --frozen-lockfile --ignore-scripts` attempt timed out locally before package build validation completed.