### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,45 +1,48 @@
 {
-	"name": "@critters-rs/astro",
-	"version": "1.2.0",
-	"description": "Astro integration for critters-rs. Quickly inline your website's critical CSS.",
-	"author": "Michael Thomas",
-	"license": "Apache-2.0",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/michaelhthomas/critters-rs"
-	},
-	"main": "index.js",
-	"type": "module",
-	"keywords": [
-		"astro-integration",
-		"astro-component",
-		"withastro",
-		"astro",
-		"critical-css"
-	],
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"default": "./dist/index.js"
-		}
-	},
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"dev": "moon run dev",
-		"build": "moon run build"
-	},
-	"devDependencies": {
-		"@types/node": "^22.7.4",
-		"astro": "^4.15.9",
-		"tsup": "^8.3.0"
-	},
-	"peerDependencies": {
-		"astro": "^4 || ^5"
-	},
-	"dependencies": {
-		"@critters-rs/critters": "workspace:^",
-		"chalk": "^5.3.0"
-	}
+  "name": "@critters-rs/astro",
+  "version": "1.2.0",
+  "bugs": {
+    "url": "https://github.com/michaelhthomas/critters-rs/issues"
+  },
+  "description": "Astro integration for critters-rs. Quickly inline your website's critical CSS.",
+  "author": "Michael Thomas",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/michaelhthomas/critters-rs"
+  },
+  "main": "index.js",
+  "type": "module",
+  "keywords": [
+    "astro-integration",
+    "astro-component",
+    "withastro",
+    "astro",
+    "critical-css"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "dev": "moon run dev",
+    "build": "moon run build"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "astro": "^4.15.9",
+    "tsup": "^8.3.0"
+  },
+  "peerDependencies": {
+    "astro": "^4 || ^5"
+  },
+  "dependencies": {
+    "@critters-rs/critters": "workspace:^",
+    "chalk": "^5.3.0"
+  }
 }


### PR DESCRIPTION
Adds missing package metadata fields to `packages/astro/package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.